### PR TITLE
Better data model

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,3 @@
 ELASTIC_NODE_URL="http://localhost:9200"
 SPAN_INDEX="jaeger-span-YYYY-MM-DD"
-#Optional
-#PORT=4000
+PORT=4000

--- a/lib/txs.ts
+++ b/lib/txs.ts
@@ -1,0 +1,35 @@
+import { ApiTx, ApiTxSchema, DbSpan, DbTx } from "../types/txs";
+
+export const getApiTxsFromDbSpans = (
+  spans: readonly DbSpan[],
+): readonly ApiTx[] =>
+  spans
+    .reduce<readonly DbTx[]>((prevTxs, span) => {
+      const foundTx = prevTxs.find((tx) => tx.traceId === span._source.traceID);
+
+      if (!foundTx) {
+        return [
+          ...prevTxs,
+          {
+            traceId: span._source.traceID,
+            startTime: span._source.startTime,
+            spans: [span],
+          },
+        ];
+      }
+
+      const spans = [...foundTx.spans, span].sort(
+        (a, b) => a._source.startTime - b._source.startTime,
+      );
+
+      const tx: DbTx = {
+        traceId: foundTx.traceId,
+        startTime: Math.min(foundTx.startTime, span._source.startTime),
+        spans,
+      };
+
+      const txs = prevTxs.toSpliced(prevTxs.indexOf(foundTx), 1, tx);
+      return txs;
+    }, [])
+    .map((tx) => ApiTxSchema.parse(tx))
+    .sort((a, b) => b.startTime - a.startTime);

--- a/routes/getTxs.ts
+++ b/routes/getTxs.ts
@@ -4,10 +4,11 @@ import { z } from "zod";
 import { elasticClient } from "../lib/elasticsearch/client";
 import { matchFields, matchTags } from "../lib/elasticsearch/queries";
 import { env } from "../lib/env";
+import { getApiTxsFromDbSpans } from "../lib/txs";
+import { DbSpan } from "../types/txs";
 
 const reqQuerySchema = z.object({
   traceID: z.optional(z.string()),
-  spanID: z.optional(z.string()),
   operationName: z.optional(z.string()),
   tags: z
     .optional(
@@ -39,7 +40,8 @@ export async function getTxs(req: Request, res: Response) {
       size: 15,
     });
 
-    const txs = result.hits.hits;
+    const spans = result.hits.hits as unknown as readonly DbSpan[];
+    const txs = getApiTxsFromDbSpans(spans);
 
     res.status(200).send({ txs });
   } catch (error: unknown) {

--- a/types/txs.ts
+++ b/types/txs.ts
@@ -1,0 +1,53 @@
+import { z } from "zod";
+
+const DbSpanSchema = z.object({
+  _source: z.object({
+    traceID: z.string(),
+    spanID: z.string(),
+    references: z
+      .array(
+        z.object({
+          refType: z.string(),
+          traceID: z.string(),
+          spanID: z.string(),
+        }),
+      )
+      .readonly(),
+    operationName: z.string(),
+    tags: z
+      .array(z.object({ key: z.string(), type: z.string(), value: z.string() }))
+      .readonly(),
+    startTime: z.number(),
+    duration: z.number(),
+  }),
+});
+
+const ApiSpanSchema = DbSpanSchema.transform(({ _source: span }) => ({
+  traceId: span.traceID,
+  spanId: span.spanID,
+  parentSpanId:
+    span.references.find(
+      (ref) => ref.traceID === span.traceID && ref.refType === "CHILD_OF",
+    )?.spanID ?? null,
+  operationName: span.operationName,
+  tags: Array.from(span.tags.map(({ key, value }) => [key, value])),
+  startTime: span.startTime,
+  duration: span.duration,
+}));
+
+export const DbTxSchema = z.object({
+  traceId: z.string(),
+  startTime: z.number(),
+  spans: z.array(DbSpanSchema).readonly(),
+});
+
+export const ApiTxSchema = z.object({
+  traceId: z.string(),
+  startTime: z.number(),
+  spans: z.array(ApiSpanSchema).readonly(),
+});
+
+export type DbSpan = Readonly<z.infer<typeof DbSpanSchema>>;
+export type ApiSpan = Readonly<z.infer<typeof ApiSpanSchema>>;
+export type DbTx = Readonly<z.infer<typeof DbTxSchema>>;
+export type ApiTx = Readonly<z.infer<typeof ApiTxSchema>>;


### PR DESCRIPTION
Instead of serving raw spans from the DB, the API will now serve traces with a `spans` field: an array containing its spans. The traces are ordered by descending `startTime`, whereas the spans are ordered by ascending `startTime`.

Example old data:

```json
[
  {
    "_index": "jaeger-span-2024-09-16",
    "_id": "o-JK-5EBBKVn7oZLpIzg",
    "_score": 8.195113,
    "_source": {
      "traceID": "52f6601e3753f9b8f5309921e635814f",
      "spanID": "81a0081900b54129",
      "flags": 1,
      "operationName": "abci_finalize_block",
      "references": [],
      "startTime": 1726497856764237,
      "startTimeMillis": 1726497856764,
      "duration": 103,
      "tags": [],
      "logs": [],
      "process": {}
    }
  },
  {
    "_index": "jaeger-span-2024-09-16",
    "_id": "wuJK-5EBBKVn7oZLpIzh",
    "_score": 8.195113,
    "_source": {
      "traceID": "52f6601e3753f9b8f5309921e635814f",
      "spanID": "ca113d074af931d0",
      "flags": 1,
      "operationName": "finalize_block",
      "references": [
        {
          "refType": "CHILD_OF",
          "traceID": "52f6601e3753f9b8f5309921e635814f",
          "spanID": "81a0081900b54129"
        }
      ],
      "startTime": 1726497856764257,
      "startTimeMillis": 1726497856764,
      "duration": 63,
      "tags": [],
      "logs": [],
      "process": {}
    }
  }
]
```

Example new data:

```json
[
  {
    "traceId": "52f6601e3753f9b8f5309921e635814f",
    "startTime": 1726497856764237,
    "spans": [
      {
        "traceId": "52f6601e3753f9b8f5309921e635814f",
        "spanId": "81a0081900b54129",
        "parentSpanId": null,
        "operationName": "abci_finalize_block",
        "tags": [],
        "startTime": 1726497856764237,
        "duration": 103
      },
      {
        "traceId": "52f6601e3753f9b8f5309921e635814f",
        "spanId": "ca113d074af931d0",
        "parentSpanId": "81a0081900b54129",
        "operationName": "finalize_block",
        "tags": [],
        "startTime": 1726497856764257,
        "duration": 63
      }
    ]
  }
]
```